### PR TITLE
Late move pruning

### DIFF
--- a/src/chessboard.hpp
+++ b/src/chessboard.hpp
@@ -139,6 +139,8 @@ class ChessBoard {
 
         inline Bitboard get_checkers(const Side side) const { return checkers[static_cast<int>(side)]; };
         inline Bitboard get_pinned_pieces(const Side side) const { return pinned_pieces[static_cast<int>(side)]; };
+        bool in_check(const Side side) const { return get_checkers(side) != 0; };
+        bool in_check() const { return in_check(get_side_to_move()); }; 
 
         Score get_midgame_score(Side side) const { return midgame_scores[static_cast<int>(side)]; };
         Score get_endgame_score(Side side) const { return endgame_scores[static_cast<int>(side)]; };

--- a/src/move.hpp
+++ b/src/move.hpp
@@ -56,6 +56,7 @@ class Move {
         bool is_capture() const { return (static_cast<int>(get_move_flags()) & 0x04) != 0; };
         bool is_promotion() const { return static_cast<int>(get_move_flags()) >= 8; };
         bool is_castling_move() const { return get_move_flags() == MoveFlags::QUEENSIDE_CASTLE || get_move_flags() == MoveFlags::KINGSIDE_CASTLE; };
+        bool is_quiet() const { return !(is_capture() || is_promotion()); };
 
         uint16_t get_history_idx(Side side_to_move) const { return (static_cast<int>(side_to_move) << 12) + get_bits(move, 11, 0); };
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -263,7 +263,7 @@ Score SearchHandler::negamax_step(Score alpha, Score beta, int depth, int ply, T
         const auto& move = moves[evaluated_moves];
 
         if constexpr(!is_pv_node(node_type)) {
-            if (depth >= 5 && !board.in_check() && move.move.is_quiet() && evaluated_quiets >= (5 + depth)) {
+            if (depth <= 6 && !board.in_check() && move.move.is_quiet() && evaluated_quiets >= depth * depth) {
                 continue;
             }
         }


### PR DESCRIPTION
Add late move pruning

```
Elo   | 27.50 +- 10.83 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1950 W: 557 L: 403 D: 990
Penta | [40, 209, 356, 297, 73]