### PR TITLE
Use stored check data for movegen

### DIFF
--- a/src/move_generator.hpp
+++ b/src/move_generator.hpp
@@ -38,7 +38,7 @@ template <MoveGenType gen_type> MoveList MoveGenerator::generate_legal_moves(con
 
     MoveGenerator::generate_moves<PieceTypes::KING, gen_type>(c, side, to_return);
 
-    int checking_piece_count = MoveGenerator::get_checking_piece_count(c, side);
+    int checking_piece_count = std::popcount(c.get_checkers(side));
 
     if (checking_piece_count >= 2) {
         return to_return;


### PR DESCRIPTION
Change how checks are calculated in movegen
```
Elo   | 11.54 +- 7.95 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 3764 W: 1030 L: 905 D: 1829
Penta | [98, 427, 729, 508, 120]