### PR TITLE
Futility pruning

### DIFF
--- a/src/chessboard.hpp
+++ b/src/chessboard.hpp
@@ -139,6 +139,8 @@ class ChessBoard {
 
         inline Bitboard get_checkers(const Side side) const { return checkers[static_cast<int>(side)]; };
         inline Bitboard get_pinned_pieces(const Side side) const { return pinned_pieces[static_cast<int>(side)]; };
+        bool in_check(const Side side) const { return checkers[static_cast<int>(side)] != 0; };
+        bool in_check() const { return in_check(get_side_to_move()); };
 
         Score get_midgame_score(Side side) const { return midgame_scores[static_cast<int>(side)]; };
         Score get_endgame_score(Side side) const { return endgame_scores[static_cast<int>(side)]; };

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -265,6 +265,11 @@ Score SearchHandler::negamax_step(Score alpha, Score beta, int depth, int ply, T
             continue;
         }
 
+        const auto fp_depth = depth + (history_table[move.move.get_history_idx(board.get_side_to_move())] / 3500);
+        if (!board.in_check() && fp_depth < 15 && static_eval + 100 * fp_depth < alpha) {
+            continue;
+        }
+
         board.make_move(move.move, history);
         node_count += 1;
         Score score;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -268,12 +268,11 @@ Score SearchHandler::negamax_step(Score alpha, Score beta, int depth, int ply, T
             }
         }
 
-        if (depth <= 10 && best_score > (MagicNumbers::NegativeInfinity + MAX_PLY) && !Search::static_exchange_evaluation(board, move.move, move.move.is_capture() ? (-20 * depth * depth) : (-65 * depth))) {
+        if (!board.in_check() && best_score > (MagicNumbers::NegativeInfinity + MAX_PLY) && !move.move.is_capture() && depth <= 6 && static_eval + 200 * depth < alpha) {
             continue;
         }
 
-        const auto fp_depth = depth + (history_table[move.move.get_history_idx(board.get_side_to_move())] / 3500);
-        if (!board.in_check() && best_score > (MagicNumbers::NegativeInfinity + MAX_PLY) && !move.move.is_capture() && fp_depth < 15 && static_eval + 100 * fp_depth < alpha) {
+        if (depth <= 10 && best_score > (MagicNumbers::NegativeInfinity + MAX_PLY) && !Search::static_exchange_evaluation(board, move.move, move.move.is_capture() ? (-20 * depth * depth) : (-65 * depth))) {
             continue;
         }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -266,7 +266,7 @@ Score SearchHandler::negamax_step(Score alpha, Score beta, int depth, int ply, T
         }
 
         const auto fp_depth = depth + (history_table[move.move.get_history_idx(board.get_side_to_move())] / 3500);
-        if (!board.in_check() && fp_depth < 15 && static_eval + 100 * fp_depth < alpha) {
+        if (!board.in_check() && !move.move.is_capture() && fp_depth < 15 && static_eval + 100 * fp_depth < alpha) {
             continue;
         }
 


### PR DESCRIPTION
Add futility pruning
```
Elo   | 7.39 +- 5.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9028 W: 2374 L: 2182 D: 4472
Penta | [256, 1043, 1753, 1177, 285]