### PR TITLE
Increase LMR in predicted cut-nodes

### DIFF
--- a/src/search.hpp
+++ b/src/search.hpp
@@ -125,7 +125,7 @@ class SearchHandler {
 
         void search_thread_function();
         Score run_aspiration_window_search(int depth, Score previous_score);
-        template <NodeTypes node_type> Score negamax_step(Score alpha, Score beta, int depth, int ply, uint64_t& node_count);
+        template <NodeTypes node_type> Score negamax_step(Score alpha, Score beta, int depth, int ply, uint64_t& node_count, bool is_cut_node);
         template <NodeTypes node_type> Score quiescent_search(Score alpha, Score beta, int ply, uint64_t& node_count);
         Move run_iterative_deepening_search();
 


### PR DESCRIPTION
Bench: 13476233
```
Elo   | 6.26 +- 4.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 11826 W: 3468 L: 3255 D: 5103