### PR TITLE
Use scores from TT for static eval

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -214,7 +214,7 @@ Score SearchHandler::negamax_step(Score alpha, Score beta, int depth, int ply, u
         extensions += 1;
     } 
 
-    const auto static_eval = Evaluation::evaluate_board(board);
+    const auto static_eval = tt_hit ? tt_entry.score() : Evaluation::evaluate_board(board);
     if (ply >= MAX_PLY) {
         return static_eval;
     }


### PR DESCRIPTION
Bench: 15202470
```
Elo   | 4.80 +- 3.87 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 19550 W: 6333 L: 6063 D: 7154