### PR TITLE
Change NMP depth reduction algorithm

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -252,9 +252,11 @@ Score SearchHandler::negamax_step(const ChessBoard& old_board, Score alpha, Scor
 
             if (!nmp_stopped) {
                 auto& board = old_board.make_move(Move::NULL_MOVE, history);
-                // First we make the null move
+                
+                const auto nmp_reduction = 4 + (depth / 4);
                 auto null_score =
-                    -negamax_step<pv_node_type>(board, -beta, -alpha, depth - 2 - (depth >= 8 ? 3 : 2), ply + 1, node_count, child_cutnode_type);
+                    -negamax_step<pv_node_type>(board, -beta, -alpha, depth - nmp_reduction, ply + 1, node_count, child_cutnode_type);
+
                 history.pop_board();
                 if (null_score >= beta) {
                     if (null_score > MagicNumbers::PositiveInfinity - MAX_PLY) {


### PR DESCRIPTION
Bench: 8717584
```
Elo   | 14.25 +- 7.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4612 W: 1558 L: 1369 D: 1685