### PR TITLE
Reduce LMR reduction if in check

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -340,7 +340,8 @@ Score SearchHandler::negamax_step(const ChessBoard& old_board, Score alpha, Scor
                                                            + static_cast<size_t>(move.move.is_capture() || move.move.is_promotion()))) {
             const auto lmr_reduction =
                 static_cast<int>(std::round(1.30 + ((MagicNumbers::LnValues[depth] * MagicNumbers::LnValues[evaluated_moves]) / 2.80)))
-                + static_cast<int>(!is_pv_node(node_type) && is_cut_node);
+                + static_cast<int>(!is_pv_node(node_type) && is_cut_node)
+                - static_cast<int>(board.in_check()); // Reduce less if the board is in check
             score = -negamax_step<NodeTypes::NON_PV_NODE>(board, -(alpha + 1), -alpha, depth - lmr_reduction + extensions, ply + 1, node_count,
                                                           child_cutnode_type);
 


### PR DESCRIPTION
Bench: 8081456
```
Elo   | 14.39 +- 8.18 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4276 W: 1406 L: 1229 D: 1641