### PR TITLE
Add depth guard to nmp

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -245,7 +245,7 @@ Score SearchHandler::negamax_step(const ChessBoard& old_board, Score alpha, Scor
     }
 
     if constexpr (!is_pv_node(node_type)) {
-        if (static_eval >= beta && !old_board.in_check()) {
+        if (static_eval >= beta && !old_board.in_check() && depth >= 3) {
             // Try null move pruning if we aren't in check
             const auto& older_board = history[history.len() - 2];
             const bool nmp_stopped =


### PR DESCRIPTION
Bench: 9964352
```
Elo   | 3.16 +- 2.53 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 5.00]
Games | N: 42500 W: 12742 L: 12355 D: 17403