### PR TITLE
Reduce number of checks in threefold repetition detection

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -68,7 +68,7 @@ bool Search::is_threefold_repetition(const BoardHistory& history, const int half
     int counter = 1;
     const int history_len = history.len();
     const auto castling_rights = history[history_len - 1].get_castling();
-    for (int i = history_len - 2; i > 0 && i > history_len - halfmove_clock - 1; i--) {
+    for (int i = history_len - 3; i > 0 && i > history_len - halfmove_clock - 1; i -= 2) {
         if (history[i].get_zobrist_key() == z) {
             counter += 1;
             if (counter >= 3) {


### PR DESCRIPTION
Bench: 9964352
```
Elo   | 1.21 +- 4.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 16948 W: 5121 L: 5062 D: 6765