### PR TITLE
Remove redundant legality check in makemove

### DIFF
--- a/src/chessboard.cpp
+++ b/src/chessboard.cpp
@@ -252,10 +252,7 @@ std::optional<int> ChessBoard::set_from_fen(const std::string input) {
 }
 
 ChessBoard::ChessBoard(const ChessBoard& origin, const Move to_make) {
-    if (!MoveGenerator::is_move_legal(origin, to_make)) {
-        origin.print_board();
-        assert(MoveGenerator::is_move_legal(origin, to_make));
-    }
+    assert(MoveGenerator::is_move_legal(origin, to_make));
 
     *this = origin;
     const auto src_sq = to_make.src_sq();


### PR DESCRIPTION
Bench: 9058549
```
Elo   | 2.57 +- 4.78 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 11762 W: 3464 L: 3377 D: 4921