### PR TITLE
Clamp LMR-reduced depth between 1 and the remaining ply

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -346,7 +346,7 @@ Score SearchHandler::negamax_step(const ChessBoard& old_board, Score alpha, Scor
             && total_moves >= std::max((size_t) 2, 1 + static_cast<size_t>(is_pv_node(node_type)) + static_cast<size_t>(!tt_move)
                                                            + static_cast<size_t>(node_type == NodeTypes::ROOT_NODE)
                                                            + static_cast<size_t>(move.move.is_capture() || move.move.is_promotion()))) {
-            const auto lmr_reduction = [&]() {
+            const auto lmr_depth = std::clamp(new_depth - [&]() {
                 int lmr_reduction = static_cast<int>(LmrTable[depth][total_moves - 1]);
                 // default log formula for lmr
                 lmr_reduction += static_cast<int>(!is_pv_node(node_type) && is_cut_node);
@@ -354,9 +354,9 @@ Score SearchHandler::negamax_step(const ChessBoard& old_board, Score alpha, Scor
                 lmr_reduction -= static_cast<int>(board.in_check());
                 // reduce less if we're in check
                 return lmr_reduction;
-            }();
+            }(), 1, MAX_PLY - ply);
             
-            score = -negamax_step<NodeTypes::NON_PV_NODE>(board, -(alpha + 1), -alpha, new_depth - lmr_reduction, ply + 1, node_count,
+            score = -negamax_step<NodeTypes::NON_PV_NODE>(board, -(alpha + 1), -alpha, lmr_depth, ply + 1, node_count,
                                                           child_cutnode_type);
 
             // it's possible the LMR score will raise alpha; in this case we re-search with the full depth


### PR DESCRIPTION
Bench: 7366929
```
Elo   | 4.66 +- 3.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 18428 W: 5350 L: 5103 D: 7975