### PR TITLE
Reduce the default size of the aspiration window

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -484,7 +484,7 @@ Score SearchHandler::quiescent_search(const Position& old_pos, Score alpha, Scor
 }
 
 Score SearchHandler::run_aspiration_window_search(int depth, Score previous_score) {
-    Score window = 40;
+    Score window = 30;
     Score alpha, beta;
     while (true) {
         if (depth <= 4) {


### PR DESCRIPTION
Bench: 7124661
```
Elo   | 5.25 +- 4.15 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 15228 W: 4424 L: 4194 D: 6610