### PR TITLE
Consider qsearch to be generating all noisy moves and vice-versa

### DIFF
--- a/src/move_generator.cpp
+++ b/src/move_generator.cpp
@@ -175,9 +175,9 @@ bool MoveGenerator::is_move_pseudolegal(const Position& pos, const Move m) {
             return std::find_if(generated_moves.begin(), generated_moves.end(), [&](ScoredMove s){ return s.move == m; }) != generated_moves.end();
         } else if (m.get_move_flags() == MoveFlags::EN_PASSANT_CAPTURE) {
             if (stm == Side::WHITE) {
-                generate_pawn_moves<MoveGenType::CAPTURES, Side::WHITE>(pos, generated_moves);
+                generate_pawn_moves<MoveGenType::NOISY, Side::WHITE>(pos, generated_moves);
             } else {
-                generate_pawn_moves<MoveGenType::CAPTURES, Side::BLACK>(pos, generated_moves);
+                generate_pawn_moves<MoveGenType::NOISY, Side::BLACK>(pos, generated_moves);
             }
             return std::find_if(generated_moves.begin(), generated_moves.end(), [&](ScoredMove s){ return s.move == m; }) != generated_moves.end();
         }


### PR DESCRIPTION
Bench: 4249976
```
Elo   | 0.57 +- 3.50 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 21218 W: 5975 L: 5940 D: 9303