### PR TITLE
Correctly filter out non-pseudolegal moves in pseudolegality check

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -55,7 +55,7 @@ HistoryValue HistoryTable::conthist_score(const BoardHistory& hist, Move move) c
 
 HistoryValue HistoryTable::capthist_score(const BoardHistory& hist, const Move move) const {
     const auto& pos = hist[hist.len() - 1];
-    const auto captured_type = (move.is_promotion() || move.get_move_flags() == MoveFlags::EN_PASSANT_CAPTURE)
+    const auto captured_type = (move.is_promotion() || move.flags() == MoveFlags::EN_PASSANT_CAPTURE)
         ? PieceTypes::PAWN
         : pos.piece_at(move.dst_sq()).get_type();
     return (*capt_hist)[pos.piece_to(move)][static_cast<int>(captured_type) - 1];
@@ -63,7 +63,7 @@ HistoryValue HistoryTable::capthist_score(const BoardHistory& hist, const Move m
 
 void HistoryTable::update_capthist_score(const BoardHistory& hist, Move move, HistoryValue bonus) {
     const auto& pos = hist[hist.len() - 1];
-    const auto captured_type = (move.is_promotion() || move.get_move_flags() == MoveFlags::EN_PASSANT_CAPTURE)
+    const auto captured_type = (move.is_promotion() || move.flags() == MoveFlags::EN_PASSANT_CAPTURE)
         ? PieceTypes::PAWN
         : pos.piece_at(move.dst_sq()).get_type();
     const auto scaled_bonus = bonus - capthist_score(hist, move) * std::abs(bonus) / 32768;

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -16,7 +16,7 @@ std::string Move::to_string() const {
     to_return.push_back(this->dst_rnk() + 49);
 
     if (this->is_promotion()) {
-        switch (this->get_promotion_piece_type()) {
+        switch (this->promo_type()) {
         case PieceTypes::ROOK:
             to_return.push_back('r');
             break;

--- a/src/move.hpp
+++ b/src/move.hpp
@@ -50,13 +50,13 @@ class Move {
         constexpr uint8_t dst_rnk() const { return get_bits(move, 11, 9); };
         constexpr uint8_t dst_fle() const { return get_bits(move, 8, 6); };
 
-        constexpr MoveFlags get_move_flags() const { return (MoveFlags) get_bits(move, 15, 12); };
-        constexpr PieceTypes get_promotion_piece_type() const { return static_cast<PieceTypes>((static_cast<int>(get_move_flags()) & 0b0011) + 2); };
+        constexpr MoveFlags flags() const { return (MoveFlags) get_bits(move, 15, 12); };
+        constexpr PieceTypes promo_type() const { return static_cast<PieceTypes>((static_cast<int>(flags()) & 0b0011) + 2); };
 
         constexpr bool is_null_move() const { return move == 0; };
-        constexpr bool is_capture() const { return (static_cast<int>(get_move_flags()) & 0x04) != 0; };
-        constexpr bool is_promotion() const { return static_cast<int>(get_move_flags()) >= 8; };
-        constexpr bool is_castling_move() const { return get_move_flags() == MoveFlags::QUEENSIDE_CASTLE || get_move_flags() == MoveFlags::KINGSIDE_CASTLE; };
+        constexpr bool is_capture() const { return (static_cast<int>(flags()) & 0x04) != 0; };
+        constexpr bool is_promotion() const { return static_cast<int>(flags()) >= 8; };
+        constexpr bool is_castling_move() const { return flags() == MoveFlags::QUEENSIDE_CASTLE || flags() == MoveFlags::KINGSIDE_CASTLE; };
         constexpr bool is_quiet() const { return !(is_capture() || is_promotion()); };
         constexpr bool is_noisy() const { return !is_quiet(); };
 

--- a/src/move_ordering.cpp
+++ b/src/move_ordering.cpp
@@ -27,7 +27,7 @@ MovePicker::MovePicker(MoveList&& input_moves, const Position& pos, const BoardH
             if (!move.see_ordering_result) {
                 move.score = -1000000;
             }
-            const auto dest_type = (move.move.is_promotion() || move.move.get_move_flags() == MoveFlags::EN_PASSANT_CAPTURE)
+            const auto dest_type = (move.move.is_promotion() || move.move.flags() == MoveFlags::EN_PASSANT_CAPTURE)
                                        ? PieceTypes::PAWN
                                        : pos.piece_at(move.move.dst_sq()).get_type();
             const auto dest_score = ordering_scores[static_cast<uint8_t>(dest_type) - 1];

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -88,12 +88,12 @@ bool Search::is_draw(const Position& pos, const BoardHistory& history) {
 }
 
 bool Search::static_exchange_evaluation(const Position& pos, const Move move, const int threshold) {
-    PieceTypes next_victim = move.is_promotion() ? move.get_promotion_piece_type() : pos.piece_at(move.src_sq()).get_type();
+    PieceTypes next_victim = move.is_promotion() ? move.promo_type() : pos.piece_at(move.src_sq()).get_type();
 
     Score balance = Search::SEEScores[static_cast<int>(pos.piece_at(move.dst_sq()).get_type())];
     if (move.is_promotion()) {
-        balance += (Search::SEEScores[static_cast<int>(move.get_promotion_piece_type())] - Search::SEEScores[static_cast<int>(PieceTypes::PAWN)]);
-    } else if (move.get_move_flags() == MoveFlags::EN_PASSANT_CAPTURE) {
+        balance += (Search::SEEScores[static_cast<int>(move.promo_type())] - Search::SEEScores[static_cast<int>(PieceTypes::PAWN)]);
+    } else if (move.flags() == MoveFlags::EN_PASSANT_CAPTURE) {
         balance = Search::SEEScores[static_cast<int>(PieceTypes::PAWN)];
     }
 
@@ -113,7 +113,7 @@ bool Search::static_exchange_evaluation(const Position& pos, const Move move, co
     Bitboard occupied = pos.occupancy();
     occupied ^= move.src_sq();
     occupied |= move.dst_sq();
-    if (move.get_move_flags() == MoveFlags::EN_PASSANT_CAPTURE) {
+    if (move.flags() == MoveFlags::EN_PASSANT_CAPTURE) {
         const auto ep_target = get_position(move.src_rnk(), move.dst_fle());
         occupied ^= ep_target;
     }
@@ -299,9 +299,9 @@ Score SearchHandler::negamax_step(const Position& old_pos, Score alpha, Score be
     }
     // mate and draw detection
 
-    auto mp = MovePicker(std::move(moves), old_pos, board_hist, tt_hit ? tt_entry.move() : Move::NULL_MOVE(), history_table,
-                                search_stack[ply].killer_move);
     const bool tt_move = tt_hit && MoveGenerator::is_move_pseudolegal(old_pos, tt_entry.move()) && MoveGenerator::is_move_legal(old_pos, tt_entry.move());
+    auto mp = MovePicker(std::move(moves), old_pos, board_hist, tt_move ? tt_entry.move() : Move::NULL_MOVE(), history_table,
+                                search_stack[ply].killer_move);
     // move reordering
 
     if (depth >= 5 && !tt_move) {

--- a/tests/chessboard_tests.cpp
+++ b/tests/chessboard_tests.cpp
@@ -116,7 +116,7 @@ TEST(ChessBoardTests, TestMakeUnmakeMove) {
     for (Square sq = Square::A1; sq != Square::NONE; sq++) {
             ASSERT_EQ(pos.piece_at(sq).get_value(), original.piece_at(sq).get_value())
                 << "Mismatch at square " << std::to_string(sq_to_int(sq)) << " after move " << m.to_string() << " with flags "
-                << std::to_string(static_cast<int>(m.get_move_flags())) << " (value " << std::to_string(m.value()) << ")";
+                << std::to_string(static_cast<int>(m.flags())) << " (value " << std::to_string(m.value()) << ")";
         }
     }
 


### PR DESCRIPTION
Bench: 4395330
```
Elo   | 3.20 +- 5.04 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 10112 W: 2852 L: 2759 D: 4501