### PR TITLE
Rewrite TT code to make it clearer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -92,5 +92,6 @@
         "resumable": "cpp",
         "span": "cpp",
         "charconv": "cpp"
-    }
+    },
+    "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools"
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -208,10 +208,10 @@ Score SearchHandler::negamax_step(const Position& old_pos, Score alpha, Score be
             // Negative infinity is being mated at this square
             // A mate score is therefore greater than (positive_infinity - max_ply) or
             // less than (negative_infinity + max_ply)
-            if (tt_entry.score() >= (MagicNumbers::PositiveInfinity - MAX_PLY)) {
-                return tt_entry.score() - ply;
+            if (tt_entry.score() == MagicNumbers::PositiveInfinity) {
+                return MagicNumbers::PositiveInfinity - ply;
             } else if (tt_entry.score() <= (MagicNumbers::NegativeInfinity + MAX_PLY)) {
-                return tt_entry.score() + ply;
+                return MagicNumbers::NegativeInfinity + ply;
             }
             return tt_entry.score();
         }
@@ -421,7 +421,7 @@ Score SearchHandler::negamax_step(const Position& old_pos, Score alpha, Score be
     }
     const BoundTypes bound_type =
         (best_score >= beta ? BoundTypes::LOWER_BOUND : (alpha != original_alpha ? BoundTypes::EXACT_BOUND : BoundTypes::UPPER_BOUND));
-    tt.store(TranspositionTableEntry(best_move, depth, bound_type, best_score, old_pos.get_zobrist_key()), old_pos, ply);
+    tt.store(TranspositionTableEntry(best_move, depth, bound_type, best_score, old_pos.get_zobrist_key()), old_pos);
     return best_score;
 }
 
@@ -456,7 +456,7 @@ Score SearchHandler::quiescent_search(const Position& old_pos, Score alpha, Scor
         if (search_cancelled) {
             break;
         }
-        const auto& move = opt_move.value();
+        const auto move = *opt_move;
 
         if (move.move.is_noisy()) {
             if (!move.see_ordering_result) {

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -96,15 +96,17 @@ class TranspositionTable {
         };
         uint64_t tt_index(const ZobristKey key) const { return static_cast<uint64_t>((static_cast<__uint128_t>(key) * static_cast<__uint128_t>(table.size())) >> 64); };
         const TranspositionTableEntry& operator[](const Position& key) const { return table[tt_index(key.get_zobrist_key())]; };
-        void store(TranspositionTableEntry entry, const Position& key, const int ply) {
+        void store(TranspositionTableEntry entry, const Position& key) {
             const auto tt_key = tt_index(key.get_zobrist_key());
             if (table[tt_key].key() != entry.key()
                 || entry.bound_type() == BoundTypes::EXACT_BOUND
                 || entry.depth() + 5 > table[tt_key].depth()) {
                 if (entry.score() <= MagicNumbers::NegativeInfinity + MAX_PLY) {
-                    entry.set_score(entry.score() - ply);
+                    // If we're being mated
+                    entry.set_score(MagicNumbers::NegativeInfinity);
                 } else if (entry.score() >= MagicNumbers::PositiveInfinity - MAX_PLY) {
-                    entry.set_score(entry.score() + ply);
+                    // If we have mate
+                    entry.set_score(MagicNumbers::PositiveInfinity);
                 }
                 if (entry.move().is_null_move()) {
                     entry.set_move(table[tt_key].move());


### PR DESCRIPTION
Bench: 4395330
```
Elo   | -0.66 +- 2.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 44420 W: 12379 L: 12463 D: 19578