### PR TITLE
Clear search stack between searches

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -579,6 +579,7 @@ Move SearchHandler::run_iterative_deepening_search() {
     for (unsigned int i = 0; i < pv_table.pv_array.size(); i++) {
         pv_table.pv_array[i].fill(Move::NULL_MOVE());
     }
+    std::for_each(search_stack.begin(), search_stack.end(), [](SearchStackFrame& elem) { elem = SearchStackFrame(); });
 
     Score current_score = 0;
     for (int depth = 1; depth <= TimeManagement::get_search_depth(tc) && !search_cancelled; depth++) {


### PR DESCRIPTION
Bench: 4644120
```
Elo   | 5.02 +- 5.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.06 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 7620 W: 2063 L: 1953 D: 3604