### PR TITLE
Use corrhist in qsearch

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -497,7 +497,7 @@ Score SearchHandler::quiescent_search(const Position& old_pos, Score alpha, Scor
     if (Search::is_draw(old_pos, board_hist)) {
         return 0;
     }
-    Score static_eval = Evaluation::evaluate_board(old_pos);
+    Score static_eval = history_table.corrhist_score(old_pos, Evaluation::evaluate_board(old_pos));
     if (ply >= MAX_PLY) {
         return static_eval;
     }


### PR DESCRIPTION
Bench: 4514233
```
Elo   | 17.12 +- 8.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3494 W: 1057 L: 885 D: 1552