### PR TITLE
Yoink IIR rewrite from pawnocchio

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -360,7 +360,9 @@ Score SearchHandler::negamax_step(const Position& old_pos, Score alpha, Score be
     // move reordering
     // tt_hit in tt_move condition guards against null entry access
 
-    if (depth >= iir_depth && !tt_move) {
+    if (depth >= iir_depth
+        && (is_pv_node(node_type) || is_cut_node)
+        && (!tt_hit || entry->get().move().is_null_move())) {
         extensions -= 1;
     }
     // iir


### PR DESCRIPTION
Bench: 5556336
```
Elo   | 5.73 +- 4.37 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 13402 W: 3947 L: 3726 D: 5729
Penta | [500, 1557, 2393, 1724, 527]
https://pyronomy.pythonanywhere.com/test/2039/