### PR TITLE
Make stm parameter in pawn movegen non-constexpr

### DIFF
--- a/src/move_generator.cpp
+++ b/src/move_generator.cpp
@@ -204,18 +204,10 @@ bool MoveGenerator::is_move_pseudolegal(const Position& pos, const Move m) {
             generate_castling_moves(pos, stm, generated_moves);
             return std::find_if(generated_moves.begin(), generated_moves.end(), [&](ScoredMove s){ return s.move == m; }) != generated_moves.end();
         } else if (m.is_promotion()) {
-            if (stm == Side::WHITE) {
-                generate_pawn_moves<MoveGenType::ALL_LEGAL, Side::WHITE>(pos, generated_moves);
-            } else {
-                generate_pawn_moves<MoveGenType::ALL_LEGAL, Side::BLACK>(pos, generated_moves);
-            }
+            generate_pawn_moves<MoveGenType::ALL_LEGAL>(pos, stm, generated_moves);
             return std::find_if(generated_moves.begin(), generated_moves.end(), [&](ScoredMove s){ return s.move == m; }) != generated_moves.end();
         } else if (m.flags() == MoveFlags::EN_PASSANT_CAPTURE) {
-            if (stm == Side::WHITE) {
-                generate_pawn_moves<MoveGenType::NOISY, Side::WHITE>(pos, generated_moves);
-            } else {
-                generate_pawn_moves<MoveGenType::NOISY, Side::BLACK>(pos, generated_moves);
-            }
+            generate_pawn_moves<MoveGenType::NOISY>(pos, stm, generated_moves);
             return std::find_if(generated_moves.begin(), generated_moves.end(), [&](ScoredMove s){ return s.move == m; }) != generated_moves.end();
         }
     }

--- a/src/move_generator.hpp
+++ b/src/move_generator.hpp
@@ -32,7 +32,7 @@ namespace MoveGenerator {
     Bitboard generate_mm(const PieceTypes pc_type, const Bitboard occupancy, const Square sq);
 
     template <PieceTypes piece_type, MoveGenType gen_type> void generate_moves(const Position& c, const Side side, MoveList& move_list);
-    template <MoveGenType gen_type, Side stm> void generate_pawn_moves(const Position& c, MoveList& move_list);
+    template <MoveGenType gen_type> void generate_pawn_moves(const Position& c, const Side stm, MoveList& move_list);
     void generate_castling_moves(const Position& c, const Side side, MoveList& move_list);
     bool can_castle(const Position& pos, const Side side, const bool is_kingside);
 
@@ -60,12 +60,7 @@ template <MoveGenType gen_type> MoveList MoveGenerator::generate_legal_moves(con
     MoveGenerator::generate_moves<PieceTypes::BISHOP, gen_type>(c, side, to_return);
     MoveGenerator::generate_moves<PieceTypes::KNIGHT, gen_type>(c, side, to_return);
     MoveGenerator::generate_moves<PieceTypes::ROOK, gen_type>(c, side, to_return);
-    if (side == Side::WHITE) {
-        MoveGenerator::generate_pawn_moves<gen_type, Side::WHITE>(c, to_return);
-    } else {
-        MoveGenerator::generate_pawn_moves<gen_type, Side::BLACK>(c, to_return);
-    }
-
+    MoveGenerator::generate_pawn_moves<gen_type>(c, side, to_return);
     return to_return;
 }
 
@@ -149,16 +144,16 @@ template <MoveGenType gen_type, MoveFlags base_flags> void gen_promotions(MoveLi
     move_list.add(Move(MoveFlags::BISHOP_PROMOTION | base_flags, dst, src));
 }
 
-template <MoveGenType gen_type, Side stm> void MoveGenerator::generate_pawn_moves(const Position& c, MoveList& move_list) {
+template <MoveGenType gen_type> void MoveGenerator::generate_pawn_moves(const Position& c, const Side stm, MoveList& move_list) {
     const auto friendly_pawns = c.pawns(stm);
     const auto occupied = c.occupancy();
     const auto pinned_pawns = friendly_pawns & c.pinned_pieces();
     const auto unpinned_pawns = pinned_pawns ^ friendly_pawns;
     const auto enemy_bb = c.occupancy(enemy_side(stm));
     const auto ksq = c.kings(stm).lsb();
-    constexpr auto ahead = stm == Side::WHITE ? 8 : -8;
-    constexpr auto back_rank = stm == Side::WHITE ? 7 : 0;
-    constexpr auto back_rank_bb = rank_bb(back_rank);
+    const auto ahead = stm == Side::WHITE ? 8 : -8;
+    const auto back_rank = stm == Side::WHITE ? 7 : 0;
+    const auto back_rank_bb = rank_bb(back_rank);
     const auto valid_dests = c.in_check() ? MagicNumbers::ConnectingSquares[sq_to_int(ksq)][sq_to_int(c.checkers().lsb())] : Bitboard(0xFFFFFFFFFFFFFFFF);
 
     const auto advanceable = unpinned_pawns | (pinned_pawns & file_bb(file(ksq)));
@@ -196,8 +191,8 @@ template <MoveGenType gen_type, Side stm> void MoveGenerator::generate_pawn_move
         // now gen captures
         {
             // towards a file
-            constexpr auto a_file = file_bb(0);
-            constexpr auto offset = stm == Side::WHITE ? 7 : -9;
+            const auto a_file = file_bb(0);
+            const auto offset = stm == Side::WHITE ? 7 : -9;
             Bitboard capturing_pieces = ([&]() {
                 const auto invalid_bb = a_file | back_rank_bb;
                 if (!(c.kings(stm) & invalid_bb).empty()) return static_cast<Bitboard>(0);
@@ -215,8 +210,8 @@ template <MoveGenType gen_type, Side stm> void MoveGenerator::generate_pawn_move
         }
         {
             // towards h file
-            constexpr auto h_file = file_bb(7);
-            constexpr auto offset = stm == Side::WHITE ? 9 : -7;
+            const auto h_file = file_bb(7);
+            const auto offset = stm == Side::WHITE ? 9 : -7;
             Bitboard capturing_pieces = ([&]() {
                 const auto invalid_bb = h_file | back_rank_bb;
                 if (!(c.kings(stm) & invalid_bb).empty()) return static_cast<Bitboard>(0);
@@ -235,11 +230,11 @@ template <MoveGenType gen_type, Side stm> void MoveGenerator::generate_pawn_move
 
 
         constexpr std::array<Bitboard, 10> ep_masks { 0x202020202020202, 0x505050505050505, 0xa0a0a0a0a0a0a0a, 0x1414141414141414, 0x2828282828282828, 0x5050505050505050, 0xa0a0a0a0a0a0a0a0, 0x4040404040404040, 0, 0 };
-        constexpr Bitboard ep_rank_mask = stm == Side::WHITE ? rank_bb(4) : rank_bb(3);
+        const Bitboard ep_rank_mask = stm == Side::WHITE ? rank_bb(4) : rank_bb(3);
         auto ep_pawns = ep_masks[c.get_en_passant_file()] & ep_rank_mask & c.pawns(stm);
         while (!ep_pawns.empty()) {
             const auto lsb = ep_pawns.pop_lsb();
-            constexpr auto ep_offset = stm == Side::WHITE ? 1 : -1;
+            const auto ep_offset = stm == Side::WHITE ? 1 : -1;
             const auto ep_target_square = get_position((stm == Side::WHITE ? 4 : 3) + ep_offset, c.get_en_passant_file());
             const auto cleared_bb = occupied ^ lsb ^ ep_target_square ^ (ep_target_square - (8 * ep_offset));
             const Bitboard threatening_bishops =

--- a/tests/move_generator_tests.cpp
+++ b/tests/move_generator_tests.cpp
@@ -11,7 +11,7 @@ TEST(MoveGeneratorTests, TestCorrectMoveCountStartPos) {
     auto lst = MoveGenerator::generate_legal_moves<MoveGenType::ALL_LEGAL>(pos, Side::WHITE);
     ASSERT_EQ(lst.size(), 20);
     MoveList m;
-    MoveGenerator::generate_pawn_moves<MoveGenType::ALL_LEGAL, Side::WHITE>(pos, m);
+    MoveGenerator::generate_pawn_moves<MoveGenType::ALL_LEGAL>(pos, Side::WHITE, m);
     ASSERT_EQ(m.size(), 16);
     m = MoveList();
     MoveGenerator::generate_moves<PieceTypes::KNIGHT, MoveGenType::ALL_LEGAL>(pos, Side::WHITE, m);
@@ -20,7 +20,7 @@ TEST(MoveGeneratorTests, TestCorrectMoveCountStartPos) {
     lst = MoveGenerator::generate_legal_moves<MoveGenType::ALL_LEGAL>(pos, Side::BLACK);
     ASSERT_EQ(lst.size(), 20);
     m = MoveList();
-    MoveGenerator::generate_pawn_moves<MoveGenType::ALL_LEGAL, Side::BLACK>(pos, m);
+    MoveGenerator::generate_pawn_moves<MoveGenType::ALL_LEGAL>(pos, Side::BLACK, m);
     ASSERT_EQ(m.size(), 16);
     m = MoveList();
     m = MoveList();
@@ -45,7 +45,7 @@ TEST(MoveGeneratorTests, TestEnPassant) {
     pos.set_en_passant_file(4);
 
     MoveList pawn_moves;
-    MoveGenerator::generate_pawn_moves<MoveGenType::ALL_LEGAL, Side::WHITE>(pos, pawn_moves);
+    MoveGenerator::generate_pawn_moves<MoveGenType::ALL_LEGAL>(pos, Side::WHITE, pawn_moves);
     ASSERT_EQ(pawn_moves.size(), 16);
 }
 
@@ -63,11 +63,11 @@ TEST(MoveGeneratorTests, TestPawnPromotions) {
     MoveList m;
     pos.set_from_fen("8/2P2k2/8/8/8/8/5K2/8 w - - 0 1");
     m = MoveList();
-    MoveGenerator::generate_pawn_moves<MoveGenType::ALL_LEGAL, Side::WHITE>(pos, m);
+    MoveGenerator::generate_pawn_moves<MoveGenType::ALL_LEGAL>(pos, Side::WHITE, m);
     ASSERT_EQ(m.size(), 4);
     pos.set_from_fen("8/5k2/8/8/8/8/2p2K2/8 w - - 0 1");
     m = MoveList();
-    MoveGenerator::generate_pawn_moves<MoveGenType::ALL_LEGAL, Side::BLACK>(pos, m);
+    MoveGenerator::generate_pawn_moves<MoveGenType::ALL_LEGAL>(pos, Side::BLACK, m);
     ASSERT_EQ(m.size(), 4);
 }
 
@@ -77,20 +77,20 @@ TEST(MoveGeneratorTests, TestPawnCapturePromotions) {
 
     pos.set_from_fen("6r1/5k1P/8/8/8/8/5K2/8 w - - 0 1");
     m = MoveList();
-    MoveGenerator::generate_pawn_moves<MoveGenType::ALL_LEGAL, Side::WHITE>(pos, m);
+    MoveGenerator::generate_pawn_moves<MoveGenType::ALL_LEGAL>(pos, Side::WHITE, m);
     ASSERT_EQ(m.size(), 8);
     pos.set_from_fen("1r6/P4k2/8/8/8/8/5K2/8 w - - 0 1");
     m = MoveList();
-    MoveGenerator::generate_pawn_moves<MoveGenType::ALL_LEGAL, Side::WHITE>(pos, m);
+    MoveGenerator::generate_pawn_moves<MoveGenType::ALL_LEGAL>(pos, Side::WHITE, m);
     ASSERT_EQ(m.size(), 8);
 
     pos.set_from_fen("8/5k2/8/8/8/8/p4K2/1R6 w - - 0 1");
     m = MoveList();
-    MoveGenerator::generate_pawn_moves<MoveGenType::ALL_LEGAL, Side::BLACK>(pos, m);
+    MoveGenerator::generate_pawn_moves<MoveGenType::ALL_LEGAL>(pos, Side::BLACK, m);
     ASSERT_EQ(m.size(), 8);
     pos.set_from_fen("8/5k2/8/8/8/8/5K1p/6R1 w - - 0 1");
     m = MoveList();
-    MoveGenerator::generate_pawn_moves<MoveGenType::ALL_LEGAL, Side::BLACK>(pos, m);
+    MoveGenerator::generate_pawn_moves<MoveGenType::ALL_LEGAL>(pos, Side::BLACK, m);
     ASSERT_EQ(m.size(), 8);
 }
 
@@ -100,12 +100,12 @@ TEST(MoveGeneratorTests, TestPawnCaptures) {
 
     pos.set_from_fen("8/5k2/1r1r4/2P5/8/8/5K2/8 w - - 0 1");
     m = MoveList();
-    MoveGenerator::generate_pawn_moves<MoveGenType::ALL_LEGAL, Side::WHITE>(pos, m);
+    MoveGenerator::generate_pawn_moves<MoveGenType::ALL_LEGAL>(pos, Side::WHITE, m);
     ASSERT_EQ(m.size(), 3);
 
     pos.set_from_fen("8/5k2/8/8/2p5/1R1R4/5K2/8 w - - 0 1");
     m = MoveList();
-    MoveGenerator::generate_pawn_moves<MoveGenType::ALL_LEGAL, Side::BLACK>(pos, m);
+    MoveGenerator::generate_pawn_moves<MoveGenType::ALL_LEGAL>(pos, Side::BLACK, m);
     ASSERT_EQ(m.size(), 3);
 }
 
@@ -187,7 +187,7 @@ TEST(MoveGeneratorTests, TestCorrectMoveCountKiwipete) {
     ASSERT_EQ(knight_moves.size(), 11);
 
     MoveList pawn_moves;
-    MoveGenerator::generate_pawn_moves<MoveGenType::ALL_LEGAL, Side::WHITE>(pos, pawn_moves);
+    MoveGenerator::generate_pawn_moves<MoveGenType::ALL_LEGAL>(pos, Side::WHITE, pawn_moves);
     ASSERT_EQ(pawn_moves.size(), 8);
 
     ASSERT_EQ(legal_moves.size(), 48);
@@ -223,7 +223,7 @@ TEST(MoveGeneratorTests, TestCorrectMoveCountKiwipeteB2B3) {
     ASSERT_EQ(knight_moves.size(), 10);
 
     MoveList pawn_moves;
-    MoveGenerator::generate_pawn_moves<MoveGenType::ALL_LEGAL, Side::BLACK>(pos, pawn_moves);
+    MoveGenerator::generate_pawn_moves<MoveGenType::ALL_LEGAL>(pos, Side::BLACK, pawn_moves);
     ASSERT_EQ(pawn_moves.size(), 7);
 
     ASSERT_EQ(legal_moves.size(), 42);
@@ -262,7 +262,7 @@ TEST(MoveGeneratorTests, TestCorrectMoveCountKiwipeteE1D1C7C6) {
     ASSERT_EQ(knight_moves.size(), 10);
 
     MoveList pawn_moves;
-    MoveGenerator::generate_pawn_moves<MoveGenType::ALL_LEGAL, Side::WHITE>(pos, pawn_moves);
+    MoveGenerator::generate_pawn_moves<MoveGenType::ALL_LEGAL>(pos, Side::WHITE, pawn_moves);
     ASSERT_EQ(pawn_moves.size(), 9);
 
     ASSERT_EQ(legal_moves.size(), 46);


### PR DESCRIPTION
Bench: 4608066
```
Elo   | 2.93 +- 2.32 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 5.00]
Games | N: 43576 W: 12291 L: 11923 D: 19362
Penta | [1390, 5108, 8554, 5216, 1520]
https://pyronomy.pythonanywhere.com/test/2289/