### PR TITLE
Remove unused function in move ordering

### DIFF
--- a/src/move_ordering.hpp
+++ b/src/move_ordering.hpp
@@ -14,6 +14,4 @@ class MovePicker {
     public:
         MovePicker(MoveList&& input_moves, const Position& pos, const BoardHistory& hist, const Move pv_move, const HistoryTable& history_table, Move killer);
         std::optional<ScoredMove> next(const bool skip_quiets);
-
-        const ScoredMove& operator[](size_t idx) { return moves[idx]; };
 };


### PR DESCRIPTION
Bench: 4617376
```
Elo   | 0.96 +- 3.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 18550 W: 5178 L: 5127 D: 8245
Penta | [620, 2159, 3654, 2234, 608]
https://pyronomy.pythonanywhere.com/test/2512/