### PR TITLE
Reduce less in LMR if examining a noisy move

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -442,6 +442,8 @@ Score SearchHandler::negamax_step(const Position& old_pos, Score alpha, Score be
                         // Reduce less if this move has a good score
                         lmr_reduction += static_cast<i32>(!tt_pv);
                         // Reduce more if not tt pv
+                        lmr_reduction -= static_cast<i32>(move.move.is_noisy());
+                        // Reduce less if a noisy move
                         return lmr_reduction;
                     }(),
                 1, new_depth);


### PR DESCRIPTION
```
Elo   | 8.24 +- 5.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8056 W: 2279 L: 2088 D: 3689
Penta | [283, 906, 1505, 1005, 329]
https://pyronomy.pythonanywhere.com/test/2924/
```
Bench: 4549143