### PR TITLE
Skip non-pv research if lmr depth does not reduce

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -457,7 +457,7 @@ Score SearchHandler::negamax_step(const Position& old_pos, Score alpha, Score be
             score = -negamax_step<NodeTypes::NON_PV_NODE>(pos, -(alpha + 1), -alpha, lmr_depth, ply + 1, node_count, child_cutnode_type);
 
             // it's possible the LMR score will raise alpha; in this case we re-search with the full depth
-            if (score > alpha) {
+            if (score > alpha && lmr_depth < new_depth) {
                 score = -negamax_step<NodeTypes::NON_PV_NODE>(pos, -(alpha + 1), -alpha, new_depth, ply + 1, node_count, child_cutnode_type);
             }
         }


### PR DESCRIPTION
STC:
```
Elo   | 2.25 +- 4.30 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 12204 W: 3285 L: 3206 D: 5713
Penta | [368, 1454, 2385, 1521, 374]
```
LTC:
```
Elo   | 0.74 +- 3.19 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 19278 W: 4428 L: 4387 D: 10463
Penta | [424, 2336, 4104, 2325, 450]
```
Bench: 4102474