### PR TITLE
Remove draw detection in qsearch

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -536,9 +536,6 @@ Score SearchHandler::negamax_step(const Position& old_pos, Score alpha, Score be
 
 template <NodeTypes node_type>
 Score SearchHandler::quiescent_search(const Position& old_pos, Score alpha, Score beta, int ply, uint64_t& node_count) {
-    if (Search::is_draw(old_pos, board_hist)) {
-        return 0;
-    }
 
     const auto entry = tt.probe(old_pos);
     const auto tt_hit = entry.has_value();


### PR DESCRIPTION
Remove draw detection in qsearch

STC:
Elo   | 0.38 +- 2.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 22946 W: 5909 L: 5884 D: 11153
Penta | [565, 2679, 4990, 2644, 595]
https://pyronomy.pythonanywhere.com/test/3600/

LTC:
Elo   | 4.23 +- 4.79 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 7400 W: 1632 L: 1542 D: 4226
Penta | [122, 803, 1780, 853, 142]
https://pyronomy.pythonanywhere.com/test/3601/

Bench: 8266525