### PR TITLE
Add check to handle cases where a king was in double check and the tt…

### DIFF
--- a/src/move_generator.cpp
+++ b/src/move_generator.cpp
@@ -142,6 +142,9 @@ bool MoveGenerator::is_move_legal(const Position& c, const Move m) {
     const auto king_idx = c.kings(c.stm()).lsb();
     const auto move_side = static_cast<Side>(c.occupancy(Side::BLACK)[m.src_sq()]);
     const Side enemy = enemy_side(move_side);
+    if (c.checkers().popcnt() >= 2 && !c.kings()[m.src_sq()]) {
+        return false;
+    }
     if (m.flags() == MoveFlags::EN_PASSANT_CAPTURE) {
         // with en passant knights and pawns _cannot_ capture as the previous
         // move was moving a pawn, and therefore knights/pawns were not in


### PR DESCRIPTION
… or killer move was a move that would be legal in single-check

Elo   | 1.92 +- 3.93 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 13030 W: 3902 L: 3830 D: 5298
Penta | [331, 1450, 2903, 1478, 353]
https://pyronomy.pythonanywhere.com/test/3626/

Bench: 7867781