### PR TITLE
Remove std::min in history bonus calculation

### DIFF
--- a/src/history.hpp
+++ b/src/history.hpp
@@ -25,7 +25,7 @@ class HistoryTable {
         std::unique_ptr<MDArray<Score, 1024, 1024>> cont_corr_hist;
 
         static size_t calc_hist_idx(Move move, Side stm) { return move.hist_idx(stm); };
-        static HistoryValue bonus(int depth) { return std::min(16 * (depth + 1) * (depth + 1), 1200); };
+        static HistoryValue bonus(int depth) { return 16 * (depth + 1) * (depth + 1); };
         static HistoryValue malus(int depth) { return -bonus(depth); };
 
     public:


### PR DESCRIPTION
STC:
Elo   | 4.55 +- 3.53 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.04 (-2.94, 2.94) [0.00, 5.00]
Games | N: 19188 W: 5812 L: 5561 D: 7815
Penta | [654, 2164, 3749, 2331, 696]
https://pyronomy.pythonanywhere.com/test/3637/
LTC:
Elo   | 4.65 +- 3.59 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 15760 W: 4353 L: 4142 D: 7265
Penta | [347, 1876, 3297, 1939, 421]
https://pyronomy.pythonanywhere.com/test/3638/
Bench: 7725900