### PR TITLE
Only perform NMP if non-pawn pieces exist on the board

### DIFF
--- a/src/chessboard.hpp
+++ b/src/chessboard.hpp
@@ -92,6 +92,8 @@ class Position {
             return piece_bbs[bb_idx(PieceTypes::PAWN)] & side_bbs[static_cast<uint8_t>(side)];
         };
 
+        inline auto has_valuable_pieces() const { return !(occupancy() ^ (kings() | pawns())).empty(); };
+
         inline Piece piece_at(const Square sq) const {
             return piece_mb[sq_to_int(sq)];
         }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -331,7 +331,7 @@ Score SearchHandler::negamax_step(const Position& old_pos, Score alpha, Score be
     }
 
     if constexpr (!is_pv_node(node_type)) {
-        if (static_eval >= beta && !old_pos.in_check() && depth >= nmp_depth && !in_singular_search) {
+        if (static_eval >= beta && !old_pos.in_check() && depth >= nmp_depth && !in_singular_search && old_pos.has_valuable_pieces()) {
             // Try null move pruning if we aren't in check
 
             if (!board_hist.move_at(board_hist.len() - 1).is_null_move()) {


### PR DESCRIPTION
STC:
Elo   | 3.86 +- 3.08 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 21494 W: 6542 L: 6303 D: 8649
Penta | [553, 2320, 4824, 2435, 615]
https://pyronomy.pythonanywhere.com/test/3645/

LTC:
Elo   | 7.30 +- 4.69 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7000 W: 1999 L: 1852 D: 3149
Penta | [82, 724, 1776, 801, 117]
https://pyronomy.pythonanywhere.com/test/3646/

Bench: 7590122