### PR TITLE
Fix bug in positive tt cutoff and rewrite to use mate/d in max ply

### DIFF
--- a/src/evaluation.cpp
+++ b/src/evaluation.cpp
@@ -19,6 +19,6 @@ Score Evaluation::evaluate_board(const Position& board) {
     const auto mg_phase = std::min(board.get_mg_phase(), (uint8_t) 24);
     const auto eg_phase = 24 - mg_phase;
 
-    return std::clamp((((mg_score * mg_phase) + (eg_score * eg_phase)) / 24) + 5, MagicNumbers::NegativeInfinity + MAX_PLY + 1,
-                      MagicNumbers::PositiveInfinity - MAX_PLY - 1);
+    return std::clamp((((mg_score * mg_phase) + (eg_score * eg_phase)) / 24) + 5, MATED_IN_MAX_PLY + 1,
+                      MATE_IN_MAX_PLY - 1);
 }

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -87,7 +87,7 @@ Score HistoryTable::corrhist_score(const Position& pos, const Score static_eval,
 
     const i32 adjusted_score = static_eval + (entry * std::abs(entry)) / 16384;
 
-    return std::clamp(adjusted_score, -MATE_FOUND + 1, MATE_FOUND - 1);
+    return std::clamp(adjusted_score, MATED_IN_MAX_PLY + 1, MATE_IN_MAX_PLY - 1);
 }
 
 void HistoryTable::update_corrhist_score(const Position& pos, const Score static_eval, const Score search_score, const int depth, const BoardHistory& hist) {

--- a/src/magic_numbers.hpp
+++ b/src/magic_numbers.hpp
@@ -38,4 +38,5 @@ namespace MagicNumbers {
     // int32_t so a known constant size
 } // namespace MagicNumbers
 
-constexpr static int MATE_FOUND = MagicNumbers::PositiveInfinity - MAX_PLY;
+constexpr static int MATE_IN_MAX_PLY = MagicNumbers::PositiveInfinity - MAX_PLY;
+constexpr static int MATED_IN_MAX_PLY = MagicNumbers::NegativeInfinity + MAX_PLY;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -251,9 +251,9 @@ Score SearchHandler::negamax_step(const Position& old_pos, Score alpha, Score be
             // Negative infinity is being mated at this square
             // A mate score is therefore greater than (positive_infinity - max_ply) or
             // less than (negative_infinity + max_ply)
-            if (entry->get().score() == MagicNumbers::PositiveInfinity) {
+            if (entry->get().score() >= MATE_IN_MAX_PLY) {
                 return MagicNumbers::PositiveInfinity - ply;
-            } else if (entry->get().score() <= (MagicNumbers::NegativeInfinity + MAX_PLY)) {
+            } else if (entry->get().score() <= MATED_IN_MAX_PLY) {
                 return MagicNumbers::NegativeInfinity + ply;
             }
             return entry->get().score();
@@ -274,7 +274,7 @@ Score SearchHandler::negamax_step(const Position& old_pos, Score alpha, Score be
     const auto raw_eval = [&]() {
         if (old_pos.in_check()) {
             return MagicNumbers::NegativeInfinity;
-        } else if (tt_hit && entry->get().static_eval() > (MagicNumbers::NegativeInfinity + MAX_PLY)) {
+        } else if (tt_hit && entry->get().static_eval() > MATED_IN_MAX_PLY) {
             return entry->get().static_eval();
         } else {
             return Evaluation::evaluate_board(old_pos);
@@ -290,7 +290,7 @@ Score SearchHandler::negamax_step(const Position& old_pos, Score alpha, Score be
     }();
 
     const auto static_eval = [&]() {
-        if (tt_hit && entry->get().score() > (MagicNumbers::NegativeInfinity + MAX_PLY)
+        if (tt_hit && entry->get().score() > MATED_IN_MAX_PLY
             && (entry->get().bound_type() == BoundTypes::EXACT_BOUND
                 || (entry->get().bound_type() == BoundTypes::LOWER_BOUND && entry->get().score() > raw_eval)
                 || (entry->get().bound_type() == BoundTypes::UPPER_BOUND && entry->get().score() < raw_eval))) {
@@ -342,7 +342,7 @@ Score SearchHandler::negamax_step(const Position& old_pos, Score alpha, Score be
 
                 board_hist.pop_board();
                 if (null_score >= beta) {
-                    if (null_score > MagicNumbers::PositiveInfinity - MAX_PLY) {
+                    if (null_score > MATE_IN_MAX_PLY) {
                         return beta;
                     } else {
                         return null_score;
@@ -392,7 +392,7 @@ Score SearchHandler::negamax_step(const Position& old_pos, Score alpha, Score be
         }
 
         // futility pruning
-        if (!old_pos.in_check() && best_score > (MagicNumbers::NegativeInfinity + MAX_PLY) && !move.move.is_noisy() && depth <= fp_depth
+        if (!old_pos.in_check() && best_score > MATED_IN_MAX_PLY && !move.move.is_noisy() && depth <= fp_depth
             && static_eval + fp_multi * depth < alpha) {
             skip_quiets = true;
             continue;
@@ -408,7 +408,7 @@ Score SearchHandler::negamax_step(const Position& old_pos, Score alpha, Score be
             }
         }
 
-        if (depth <= see_prune_depth && best_score > (MagicNumbers::NegativeInfinity + MAX_PLY)
+        if (depth <= see_prune_depth && best_score > MATED_IN_MAX_PLY
             && !Search::static_exchange_evaluation(
                 old_pos, move.move, move.move.is_noisy() ? (noisy_see_prune_multi * depth * depth) : (quiet_see_prune_multi * depth))) {
             continue;
@@ -423,7 +423,7 @@ Score SearchHandler::negamax_step(const Position& old_pos, Score alpha, Score be
             if constexpr (node_type == NodeTypes::ROOT_NODE) return false;
             if (tt_hit && depth >= 8 && move.move == entry->get().move() && !in_singular_search
                 && entry->get().depth() + 4 >= depth && entry->get().bound_type() != BoundTypes::UPPER_BOUND
-                && std::abs(entry->get().score()) < (MagicNumbers::PositiveInfinity - MAX_PLY)) {
+                && std::abs(entry->get().score()) < MATE_IN_MAX_PLY) {
                     // Do SE
                     const auto se_depth = (depth - 1) / 2;
                     const auto se_beta = entry->get().score() - (3 * depth);
@@ -526,7 +526,7 @@ Score SearchHandler::negamax_step(const Position& old_pos, Score alpha, Score be
     const BoundTypes bound_type =
         (best_score >= beta ? BoundTypes::LOWER_BOUND : (alpha != original_alpha ? BoundTypes::EXACT_BOUND : BoundTypes::UPPER_BOUND));
 
-    if (!old_pos.in_check() && std::abs(best_score) < MATE_FOUND && (best_move.is_null_move() || best_move.is_quiet())
+    if (!old_pos.in_check() && std::abs(best_score) < MATE_IN_MAX_PLY && (best_move.is_null_move() || best_move.is_quiet())
         && !(bound_type == BoundTypes::LOWER_BOUND && best_score <= adjusted_eval)
         && !(bound_type == BoundTypes::UPPER_BOUND && best_score >= adjusted_eval)) {
         history_table.update_corrhist_score(old_pos, adjusted_eval, best_score, depth, board_hist);
@@ -555,7 +555,7 @@ Score SearchHandler::quiescent_search(const Position& old_pos, Score alpha, Scor
     const auto raw_eval = [&]() {
         if (old_pos.in_check()) {
             return MagicNumbers::NegativeInfinity;
-        } else if (tt_hit && entry->get().static_eval() > (MagicNumbers::NegativeInfinity + MAX_PLY)) {
+        } else if (tt_hit && entry->get().static_eval() > MATED_IN_MAX_PLY) {
             return entry->get().static_eval();
         } else {
             return Evaluation::evaluate_board(old_pos);
@@ -588,7 +588,7 @@ Score SearchHandler::quiescent_search(const Position& old_pos, Score alpha, Scor
     Move best_move = Move::NULL_MOVE();
     std::optional<ScoredMove> opt_move;
     auto found_move = false;
-    while ((opt_move = mp.next(best_score > (MagicNumbers::NegativeInfinity + MAX_PLY))).has_value()) {
+    while ((opt_move = mp.next(best_score > MATED_IN_MAX_PLY)).has_value()) {
         if (search_cancelled) {
             break;
         }
@@ -716,7 +716,7 @@ Move SearchHandler::run_iterative_deepening_search() {
         if (!search_cancelled && print_info) {
             const auto nps = static_cast<uint64_t>(node_count / (static_cast<float>(time_so_far) / 1000));
             fmt::print("info depth {} nodes {} nps {} score ", depth, node_count, nps);
-            if ((std::abs(current_score) >= (MagicNumbers::PositiveInfinity - MAX_PLY))) {
+            if ((std::abs(current_score) >= MATE_IN_MAX_PLY)) {
                 fmt::print("mate {} ", ((current_score / std::abs(current_score)) * (depth + 1)) / 2);
             } else {
                 fmt::print("cp {} ", current_score);
@@ -728,7 +728,7 @@ Move SearchHandler::run_iterative_deepening_search() {
             fmt::println("");
         }
 
-        if (current_score >= (MagicNumbers::PositiveInfinity - MAX_PLY)) {
+        if (current_score >= MATE_IN_MAX_PLY) {
             return pv_move;
         }
 


### PR DESCRIPTION
STC:
Elo   | 0.75 +- 3.24 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.11 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 20960 W: 6084 L: 6039 D: 8837
Penta | [628, 2463, 4241, 2532, 616]
https://pyronomy.pythonanywhere.com/test/3834/

LTC:
Elo   | 3.70 +- 4.62 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.08 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 9006 W: 2455 L: 2359 D: 4192
Penta | [178, 1073, 1935, 1109, 208]
https://pyronomy.pythonanywhere.com/test/3849/

Bench: 7584599