### PR TITLE
Check for draw in qsearch

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -539,6 +539,10 @@ Score SearchHandler::negamax_step(const Position& old_pos, Score alpha, Score be
 template <NodeTypes node_type>
 Score SearchHandler::quiescent_search(const Position& old_pos, Score alpha, Score beta, int ply, uint64_t& node_count) {
 
+    if (Search::is_draw(old_pos, board_hist)) {
+        return 0;
+    }
+
     const auto entry = tt.probe(old_pos);
     const auto tt_hit = entry.has_value();
     if constexpr (!is_pv_node(node_type)) {


### PR DESCRIPTION
```
Elo   | 0.92 +- 3.43 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 18478 W: 5521 L: 5472 D: 7485
Penta | [533, 2160, 3822, 2173, 551]
```
Bench: 8215780